### PR TITLE
fix: message_body can be send empty in bs5_products_inquiry

### DIFF
--- a/new_files/bs5_product_inquiry.php
+++ b/new_files/bs5_product_inquiry.php
@@ -116,7 +116,7 @@ if (isset($_POST['action']) && ($_POST['action'] == 'send')) {
 		$error = true;
 		$messageStack->add('product_inquiry', ENTRY_EMAIL_ADDRESS_CHECK_ERROR);
 	}
-	if (strlen($message_body) == '') {
+	if (strlen($message_body) == 0) {
 		$error = true;
 		$messageStack->add('product_inquiry', BS5_ENTRY_MESSAGE_BODY_ERROR);
 	}


### PR DESCRIPTION
message_body can be send empty if strlen() equals to an empty string, strlen() always returns an integer