### PR TITLE
always keep the subject the same even if errors occur in the form

### DIFF
--- a/new_files/bs5_cheaply_see.php
+++ b/new_files/bs5_cheaply_see.php
@@ -261,7 +261,7 @@ $smarty->assign('SELECT_GENDER', $select_gender);
 $smarty->assign('INPUT_FIRSTNAME', xtc_draw_input_field('firstname', ($error ? $_POST['firstname'] : (isset($_SESSION["customer_first_name"]) ? $_SESSION["customer_first_name"] : '')), 'id="firstname" class="form-control"'));
 $smarty->assign('INPUT_LASTNAME', xtc_draw_input_field('lastname', ($error ? $_POST['lastname'] : (isset($_SESSION["customer_last_name"]) ? $_SESSION["customer_last_name"] : '')), 'id="lastname" class="form-control"'));
 $smarty->assign('INPUT_EMAIL', xtc_draw_input_field('email', ($error ? $_POST['email'] : (isset($_SESSION["customer_email_address"]) ? $_SESSION["customer_email_address"] : '')), 'id="email" class="form-control"'));
-$smarty->assign('SELECT_SUBJECT', xtc_draw_input_field('subject', ($error ? $_POST['subject'] : BS5_CONTACT_SUBJECT_4), 'id="subject" class="form-control" disabled readonly'));
+$smarty->assign('SELECT_SUBJECT', xtc_draw_input_field('subject', BS5_CONTACT_SUBJECT_4, 'id="subject" class="form-control" disabled readonly'));
 $smarty->assign('INPUT_COMPETITOR_URL', xtc_draw_input_field('competitorurl', ($error ? $_POST['competitorurl'] : ''), 'id="competitorurl" class="form-control"'));
 $smarty->assign('INPUT_COMPETITOR_PRICE', xtc_draw_input_field('competitorprice', ($error ? $_POST['competitorprice'] : ''), 'id="competitorprice" class="form-control"'));
 $smarty->assign('INPUT_TEXT', xtc_draw_textarea_field('message_body', 'soft', 50, 12, $text_body, 'class="form-control"'));

--- a/new_files/bs5_product_inquiry.php
+++ b/new_files/bs5_product_inquiry.php
@@ -221,7 +221,7 @@ $smarty->assign('INPUT_FIRSTNAME', xtc_draw_input_field('firstname', ($error ? $
 $smarty->assign('INPUT_LASTNAME', xtc_draw_input_field('lastname', ($error ? $_POST['lastname'] : (isset($_SESSION["customer_last_name"]) ? $_SESSION["customer_last_name"] : '')), 'id="lastname" class="form-control"'));
 $smarty->assign('INPUT_EMAIL', xtc_draw_input_field('email', ($error ? $_POST['email'] : (isset($_SESSION["customer_email_address"]) ? $_SESSION["customer_email_address"] : '')), 'id="email" class="form-control"'));
 $smarty->assign('INPUT_PHONE', xtc_draw_input_field('phone', ($error ? $_POST['phone'] : ''), 'id="phone" class="form-control"'));
-$smarty->assign('SELECT_SUBJECT', xtc_draw_input_field('subject', ($error ? $_POST['subject'] : BS5_TEXT_PRODUCT_INQUIRY), 'id="subject" class="form-control" disabled readonly'));
+$smarty->assign('SELECT_SUBJECT', xtc_draw_input_field('subject', BS5_TEXT_PRODUCT_INQUIRY, 'id="subject" class="form-control" disabled readonly'));
 $smarty->assign('INPUT_TEXT', xtc_draw_textarea_field('message_body', 'soft', 50, 12, ($error ? $_POST['message_body'] : ''), 'class="form-control"'));
 $smarty->assign('BUTTON_SUBMIT', xtc_image_submit('button_send.gif', IMAGE_BUTTON_SEND));
 $smarty->assign('FORM_END', '</form>');


### PR DESCRIPTION
Both forms have a fixed subject line that can't be changed by the user. This change will default the subject to 'TEXT_PRODUCT_INQUIRY' regardless of any potential previous errors.